### PR TITLE
avoid \@ signs (representing nulls) in log files

### DIFF
--- a/metadata.hpp
+++ b/metadata.hpp
@@ -116,12 +116,12 @@
 #define COLORTEXT_YELLOW    "\033[33;1m"
 #define COLORTEXT_RESET     "\033[0m"
 #else
-#define COLORTEXT_WHITE     '\0'
-#define COLORTEXT_CYAN      '\0'
-#define COLORTEXT_GREEN     '\0'
-#define COLORTEXT_RED       '\0'
-#define COLORTEXT_YELLOW    '\0'
-#define COLORTEXT_RESET     '\0'
+#define COLORTEXT_WHITE     ""
+#define COLORTEXT_CYAN      ""
+#define COLORTEXT_GREEN     ""
+#define COLORTEXT_RED       ""
+#define COLORTEXT_YELLOW    ""
+#define COLORTEXT_RESET     ""
 #endif
 
 // header structure for GADGET-2 files [V. Springel, N. Yoshida, and S.D. White, New Astron. 6 (2001) 79


### PR DESCRIPTION
The byte consisting of one null character differs from the 1-character string
consisting of only the terminating byte; the latter is a pointer to a non-null
address. Running gevolution and storing the stdout+stderr log file with the old version
of this file gives null characters in the output, which looks bad when reading
the log, and is probably not a safe programming practice (hidden characters
in a plain text file).

I haven't tested the option with -DCOLORTERMINAL - my guess is that that does
not need any changes.